### PR TITLE
Remove Optional Chaining

### DIFF
--- a/plugin-page-title/src/plugin-page-title.js
+++ b/plugin-page-title/src/plugin-page-title.js
@@ -8,11 +8,11 @@ const changeTitlePlugin = async (html, route) => {
 		const dom = new JSDOM(html);
 		const routeTitle =
 			route.title ||
-			route?.data?.title ||
+			(route.data && route.data.title) ||
 			route.pageTitle ||
-			route?.data?.pageTitle ||
+			(route.data && route.data.pageTitle) ||
 			route.page_title ||
-			route?.data?.page_title;
+			(route.data && route.data.page_title);
 		if (routeTitle) {
 			log(`Page title attribute found for ${yellow(route.route)}.`);
 			const { window } = dom;


### PR DESCRIPTION
fix: 🐛 remove optional chaining

Optional chaining is not supported everywhere, so removing that and
checking that route.data exists before accessing an attribute on it is
more versatile

Closes: #6

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Uses optional chaining
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6 

## What is the new behavior?
Just checks that the route.data object exists first

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
